### PR TITLE
Fix the issue in the deployment scripts, related to the (uninstalled) beacon package

### DIFF
--- a/beacon/utils/json.py
+++ b/beacon/utils/json.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from json.encoder import py_encode_basestring_ascii
 from bson.objectid import ObjectId
 
-from asyncpg import Record
+#from asyncpg import Record
 
 from json import loads as parse_json
 
@@ -27,7 +27,8 @@ def is_list(o):
 
 
 def is_dict(o):
-    return isinstance(o, (dict, Record))
+    #return isinstance(o, (dict, Record))
+    return isinstance(o, dict)
 
 
 def is_asyncgen(o):

--- a/deploy/extract_filtering_terms.py
+++ b/deploy/extract_filtering_terms.py
@@ -11,9 +11,10 @@ import progressbar
 from bson.objectid import ObjectId
 from owlready2 import OwlReadyOntologyParsingError
 from tqdm import tqdm
-from beacon import conf
 
-from beacon.request.ontologies import ONTOLOGY_REGEX
+import conf
+#from beacon.request.ontologies import ONTOLOGY_REGEX
+ONTOLOGY_REGEX = re.compile(r"([_A-Za-z]+):(\w+)")
 
 client = MongoClient(
     "mongodb://{}:{}@{}:{}/{}?authSource={}".format(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
-# I noticed a misbehaviour with 3.7.2 regarding cookie storage for raised HTTP response
-# That's the case for the HTTPFound redirections
-# It seems the cookies are not sent in the response, and therefore, the browser does not store them
-# Obviously, sessions do not work then, and Openid Connect auth.py code is broken
 aiohttp==3.8.1
-asyncpg~=0.24.0
 pyyaml~=5.4.1
 cryptography~=35.0.0
 jinja2~=3.0.2


### PR DESCRIPTION
<!-- Describe the pull request as the first paragraph of this PR. -->
<!-- Make sure that you have read the "Contributing" guidelines. -->

### What it is about:
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation
<!-- Replace [ ] with [x] to select options. -->
<!-- Add/Remove items to the list, if necessary. -->

### Pull request long description:
Removed the beacon package reference and the Postgres dependencies.

### Related issues:
Fixes #94 

### Additional information:

If the beacon package was installed, it would be found.
You can fiddle with PYTHONPATH but I don't recommend it.
Moreover, the extract_*.py is executed on the machine, while the package is installed in some container.

An alternative is to run the deployment steps in bootstrapped container, that would connect to the locally deployed MongoDB. Then you turn off that container (or let it finish its script).

You can also include a `setup.py` file and _install_ the beacon package. The previous version of the repo would then work.

Note: `docker-compose up -d beacon` still fails with
```
ValueError: could not find a parser to parse 'http://purl.obolibrary.org/obo/doid/obo/ext.owl'
```
which seems to come, not from the beacon, [but from one of the imported packages: `pronto.ontology`](/EGA-archive/beacon2-ri-api/blob/master/beacon/request/ontologies.py#L81)
