### PR TITLE
fix response summary

### DIFF
--- a/beacon/response/build_response.py
+++ b/beacon/response/build_response.py
@@ -25,41 +25,17 @@ def build_meta(qparams: RequestParams, entity_schema: Optional[DefaultSchemas], 
     }
     return meta
 
-def build_response_summary(exists, qparams, num_total_results):
-    limit = qparams.query.pagination.limit
-    include = qparams.query.include_resultset_responses
+def build_response_summary(exists, num_total_results):
     LOG.debug(num_total_results)
-    #if limit != 0 and limit < num_total_results:
-    if include == 'NONE':
-        if num_total_results is None:
-            return {
-                'exists': exists
-            }
-        else:
-            return {
-                'exists': exists,
-                'numTotalResults': num_total_results
-            }
-    elif limit and num_total_results and limit < num_total_results:
-        if num_total_results is None:
-            return {
-                'exists': exists
-            }
-        else:
-            return {
-                'exists': exists,
-                'numTotalResults': limit
-            }
+    if num_total_results is None:
+        return {
+            'exists': exists
+        }
     else:
-        if num_total_results is None:
-            return {
-                'exists': exists
-            }
-        else:
-            return {
-                'exists': exists,
-                'numTotalResults': num_total_results
-            }
+        return {
+            'exists': exists,
+            'numTotalResults': num_total_results
+        }
 
 
 def build_response_summary_by_dataset(exists, num_total_results, data):
@@ -152,7 +128,7 @@ def build_beacon_resultset_response(data,
 
     beacon_response = {
         'meta': build_meta(qparams, entity_schema, Granularity.RECORD),
-        'responseSummary': build_response_summary(num_total_results > 0, qparams, num_total_results),
+        'responseSummary': build_response_summary(num_total_results > 0, num_total_results),
         # TODO: 'extendedInfo': build_extended_info(),
         'response': {
             'resultSets': [build_response(data, num_total_results, qparams, func_response_type)]
@@ -198,7 +174,7 @@ def build_beacon_count_response(data,
 
     beacon_response = {
         'meta': build_meta(qparams, entity_schema, Granularity.COUNT),
-        'responseSummary': build_response_summary(num_total_results > 0, qparams, num_total_results),
+        'responseSummary': build_response_summary(num_total_results > 0, num_total_results),
         # TODO: 'extendedInfo': build_extended_info(),
         'beaconHandovers': beacon_handovers(),
     }
@@ -219,7 +195,7 @@ def build_beacon_boolean_response(data,
 
     beacon_response = {
         'meta': build_meta(qparams, entity_schema, Granularity.BOOLEAN),
-        'responseSummary': build_response_summary(num_total_results > 0, qparams, None),
+        'responseSummary': build_response_summary(num_total_results > 0, None),
         # TODO: 'extendedInfo': build_extended_info(),
         'beaconHandovers': beacon_handovers(),
     }
@@ -232,7 +208,7 @@ def build_beacon_boolean_response(data,
 def build_beacon_collection_response(data, num_total_results, qparams: RequestParams, func_response_type, entity_schema: DefaultSchemas):
     beacon_response = {
         'meta': build_meta(qparams, entity_schema, Granularity.RECORD),
-        'responseSummary': build_response_summary(num_total_results > 0, qparams, num_total_results),
+        'responseSummary': build_response_summary(num_total_results > 0, num_total_results),
         # TODO: 'info': build_extended_info(),
         'beaconHandovers': beacon_handovers(),
         'response': {
@@ -320,7 +296,7 @@ def build_filtering_terms_response(data,
 
     beacon_response = {
         'meta': build_meta(qparams, entity_schema, Granularity.RECORD),
-        'responseSummary': build_response_summary(num_total_results > 0, qparams, num_total_results),
+        'responseSummary': build_response_summary(num_total_results > 0, num_total_results),
         # TODO: 'extendedInfo': build_extended_info(),
         'response': {
             'filteringTerms': data,


### PR DESCRIPTION
`numTotalResults` in the response summary is supposed to show the total number of results found by the query, regardless of pagination ([see the spec](https://github.com/ga4gh-beacon/beacon-v2/blob/main/framework/src/common/beaconCommonComponents.yaml#L209-L216)). 

In some cases, the reference implementation will spuriously return pagination values instead of the total number of results. Here is an example:

- deploy beacon according to deploy/README.md
- query /api/individuals with the following payload (taken from the readme),  `numTotalResults` will be 31 using the example data provided.
```
{
    "meta": {
        "apiVersion": "2.0"
    },
    "query": {
        "requestParameters": {
    "alternateBases": "G" ,
    "referenceBases": "A" ,
"start": [ 16050074 ],
            "end": [ 16050568 ],
	    "variantType": "SNP"
        },
        "filters": [],
        "includeResultsetResponses": "HIT",
        "pagination": {
            "skip": 0,
            "limit": 10
        },
        "testMode": false,
        "requestedGranularity": "record"
    }
}
```
- repeat the request, but change requestedGranularity to "count". `numTotalResults` will be 10 instead of 31, because build_response_summary() spuriously compares total results and pagination `limit` and returns whichever is smaller. 

The fix is to not overwrite numTotalResults with a different value. There were a number of cases and one function parameter that are no longer necessary. 

