### PR TITLE
Fix readme file links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ OIDC_RP_CLIENT_SECRET='your_client_secret'
 ```
 
 Please, bear in mind that the name of the user has to be the same that you used when creating the user in LS or in IDP, whatever the AAI method you are working with.
-To give a user a certain type of response for their queries, please modify this file [response_type.yml](https://github.com/EGA-archive/beacon2-ri-api/blob/master/beacon/request/response_type.yml) adding the maximum type of response you want to allow every user.
+To give a user a certain type of response for their queries, please modify this file [response_type.yml](beacon/request/response_type.yml) adding the maximum type of response you want to allow every user.
 
 Also, you will need to edit the file [conf.py](beacon/conf.py) and introduce the domain where your keycloak is being hosted inside **idp_url**. 
 
@@ -57,7 +57,7 @@ middlewares=[web.normalize_path_middleware(), middlewares.error_middleware, cors
 ```
 ### Beacon security system
 
-![Beacon security](https://github.com/EGA-archive/beacon2-ri-api/blob/develop/deploy/beacon_security.png?raw=true)
+![Beacon security](deploy/beacon_security.png)
 
 ### Version notes
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -78,7 +78,7 @@ Then, repeat the same for the cohorts modifying this file [cohorts.yml](../beaco
 
 #### Fetch the ontologies and extract the filtering terms
 
-> This step consists of analyzing all the collections of the Mongo database for first extracting the ontology OBO files and then filling the filtering terms endpoint with the information of the data loaded in the database.∫
+> This step consists of analyzing all the collections of the Mongo database for first extracting the ontology OBO files and then filling the filtering terms endpoint with the information of the data loaded in the database.
 
 You can automatically fetch the ontologies and extract the filtering terms running the following script:
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -73,8 +73,8 @@ docker exec beacon python beacon/reindex.py
 
 #### List the ids
 
-After deploying all the data, you will need to tell the beacon which are the individual and biosample ids belonging to each dataset and cohort. In order to do that, please, add the name of each dataset with the respective array of all the ids together in this file [datasets.yml](https://github.com/EGA-archive/beacon2-ri-api/blob/master/beacon/request/datasets.yml).
-Then, repeat the same for the cohorts modifying this file [cohorts.yml](https://github.com/EGA-archive/beacon2-ri-api/blob/master/beacon/request/cohorts.yml).
+After deploying all the data, you will need to tell the beacon which are the individual and biosample ids belonging to each dataset and cohort. In order to do that, please, add the name of each dataset with the respective array of all the ids together in this file [datasets.yml](../beacon/request/datasets.yml).
+Then, repeat the same for the cohorts modifying this file [cohorts.yml](../beacon/request/cohorts.yml).
 
 #### Fetch the ontologies and extract the filtering terms
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 ## Deploy
 
-Use the deployment for all the containers for beacon to also deploy the UI [Deployment](https://github.com/EGA-archive/beacon2-ri-api/blob/develop/deploy/README.md). You will find it running in http://localhost:3000
+Use the deployment for all the containers for beacon to also deploy the UI [Deployment](../deploy/README.md). You will find it running in http://localhost:3000
 
 ## Instructions on how to configure the Beacon User Interface
  
@@ -18,7 +18,7 @@ Tip: for Life Science environment, please first [create a user](https://lifescie
 After that you will need to register a service registry in order to be able to administrate your logins. Please go [here](https://services.aai.lifescience-ri.eu/spreg/) and ask for a New Service - type OIDC -.
 
 
-Then please edit the file config.json, which can be found inside folder [frontend/src](https://github.com/EGA-archive/beacon2-ri-api/blob/develop/frontend/src/config.json). You need to decide where you want the UI to point to when making requests. Find below an example:
+Then please edit the file [config.json](src/config.json). You need to decide where you want the UI to point to when making requests. Find below an example:
 
  ```bash
 {


### PR DESCRIPTION
At several points in the READMEs you're instructed to modify files. Sometimes you're given a local link to a file, but often you get a github url that opens in the browser, forcing you to figure out where the file is and navigate the code by hand. I've corrected these to local file links where it made sense. 

Also: 
- fixed a README image link to point to the image in the repo instead of github (othwise not much sense having the image in the repo... )
- removed one typo 
